### PR TITLE
correct src/rail/delight/__init__.py with from rail.estimation.algos.…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["rail","rail.delight","rail.estimation"]
+
 [tool.setuptools_scm]
 write_to = "src/rail/delight/_version.py"
 

--- a/src/rail/delight/__init__.py
+++ b/src/rail/delight/__init__.py
@@ -1,3 +1,3 @@
 from ._version import __version__
 
-from rail.estimation.algos.delightPZ import *
+from rail.estimation.algos.delight_hybrid import *


### PR DESCRIPTION
…delight_hybrid import * and add the [tool.setuptools.packages.find]

## Problem & Solution Description (including issue #)


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
